### PR TITLE
Remove an optimization for simple components. Removes a workaround ne…

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -39,17 +39,12 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
 
     public static String toString(BaseComponent component)
     {
-        // 1.9 Requires the first component to not be a plain string which can
-        // happen if a text component has no formatting. This optimization is
-        // still useful when nested more so we just manually wrap everything in
-        // an extra text component.
-        return "{\"text\":\"\", \"extra\": [" + gson.toJson( component ) + "]}";
+        return gson.toJson( component );
     }
 
     public static String toString(BaseComponent... components)
     {
-        // See above
-        return "{\"text\":\"\", \"extra\": [" + gson.toJson( new TextComponent( components ) ) + "]}";
+        return gson.toJson( new TextComponent( components ) );
     }
 
     @Override

--- a/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -31,12 +30,11 @@ public class TextComponentSerializer extends BaseComponentSerializer implements 
     public JsonElement serialize(TextComponent src, Type typeOfSrc, JsonSerializationContext context)
     {
         List<BaseComponent> extra = src.getExtra();
-        if ( !src.hasFormatting() && ( extra == null || extra.isEmpty() ) )
-        {
-            return new JsonPrimitive( src.getText() );
-        }
         JsonObject object = new JsonObject();
-        serialize( object, src, context );
+        if ( src.hasFormatting() || ( extra != null && !extra.isEmpty() ) )
+        {
+            serialize( object, src, context );
+        }
         object.addProperty( "text", src.getText() );
         return object;
     }


### PR DESCRIPTION
…eded for 1.9

Previously we could optimize components with only a text value to a string
instead of a full object but with 1.9 we can no longer do this for every case.
The size reduction from this optimization was small anyway.