### PR TITLE
Added opportunity to set a display string to the player count display

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -130,6 +130,12 @@ public class BungeeCord extends ProxyServer
      */
     @Getter
     public final PluginManager pluginManager = new PluginManager( this );
+    /**
+     * String displayed instead of the typical version string (will send an incompatible version to the client to show it)
+     */
+    @Getter
+    @Setter
+    private String versionDisplay;
     @Getter
     @Setter
     private ReconnectHandler reconnectHandler;

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -235,9 +235,16 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             ( (BungeeServerInfo) forced ).ping( pingBack, handshake.getProtocolVersion() );
         } else
         {
-            int protocol = ( Protocol.supportedVersions.contains( handshake.getProtocolVersion() ) ) ? handshake.getProtocolVersion() : bungee.getProtocolVersion();
+            String versionSent = bungee.getVersionDisplay();
+            int protocol = 0;
+            if ( versionSent == null )
+            {
+                versionSent = bungee.getName() + " " + bungee.getGameVersion();
+                protocol = ( Protocol.supportedVersions.contains( handshake.getProtocolVersion() ) ) ? handshake.getProtocolVersion() : bungee.getProtocolVersion();
+            }
+
             pingBack.done( new ServerPing(
-                    new ServerPing.Protocol( bungee.getName() + " " + bungee.getGameVersion(), protocol ),
+                    new ServerPing.Protocol( versionSent, protocol ),
                     new ServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount(), null ),
                     motd, BungeeCord.getInstance().config.getFaviconObject() ),
                     null );


### PR DESCRIPTION
This change will give you the opportunity to change the text which is shown in the player count bar (it effectively changes the server version to zero and sets the version string of the server)
You can access this field using reflection only (field name: net.md_5.bungee.BungeeCord.versionDisplay)