### PR TITLE
Do not change ComponentBuilder's contents when calling create()

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -242,8 +242,9 @@ public class ComponentBuilder
      */
     public BaseComponent[] create()
     {
-        parts.add( current );
-        return parts.toArray( new BaseComponent[ parts.size() ] );
+        BaseComponent[] result = parts.toArray( new BaseComponent[ parts.size() + 1 ] );
+        result[parts.size()] = current;
+        return result;
     }
 
     public static enum FormatRetention


### PR DESCRIPTION
This allows continuing to use ComponentBuilder after create() has been called.