### PR TITLE
Add support for FML with IP Forwarding enabled

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -98,8 +98,7 @@ public class ServerConnector extends PacketHandler
             copiedHandshake.setHost(newHost);
         }
         else if (!user.getExtraDataInHandshake().isEmpty())
-            // Only restore the extra data if IP forwarding is off. 
-            // TODO: Add support for this data with IP forwarding.
+            // Restore the extra data
             copiedHandshake.setHost(copiedHandshake.getHost() + user.getExtraDataInHandshake());
         
         channel.write(copiedHandshake);

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.util.internal.PlatformDependent;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -37,6 +38,8 @@ import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.score.Scoreboard;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.connection.InitialHandler;
+import net.md_5.bungee.connection.LoginResult;
+import net.md_5.bungee.connection.LoginResult.Property;
 import net.md_5.bungee.entitymap.EntityMap;
 import net.md_5.bungee.forge.ForgeClientHandler;
 import net.md_5.bungee.forge.ForgeConstants;
@@ -180,8 +183,32 @@ public final class UserConnection implements ProxiedPlayer
 
         forgeClientHandler = new ForgeClientHandler( this );
 
+        // No-config FML handshake marker.
         // Set whether the connection has a 1.8 FML marker in the handshake.
-        forgeClientHandler.setFmlTokenInHandshake( this.getPendingConnection().getExtraDataInHandshake().contains( ForgeConstants.FML_HANDSHAKE_TOKEN ) );
+        if (this.getPendingConnection().getExtraDataInHandshake().contains( ForgeConstants.FML_HANDSHAKE_TOKEN )) 
+        {
+            forgeClientHandler.setFmlTokenInHandshake( true );
+
+            // If we IP forward, add the a FML marker to the game profile.
+            if ( BungeeCord.getInstance().config.isIpForward() ) 
+            {
+                // Get the user profile.
+                LoginResult profile = pendingConnection.getLoginProfile();
+
+                // Get the current properties and copy them into a slightly bigger array.
+                Property[] oldp = profile.getProperties();
+                Property[] newp = Arrays.copyOf( oldp, oldp.length + 2 );
+
+                // Add a new profile property that specifies that this user is a Forge user.
+                newp[newp.length - 2] = new Property( ForgeConstants.FML_LOGIN_PROFILE, "true", null );
+
+                // If we do not perform the replacement, then the IP Forwarding code in Spigot et. al. will try to split on this prematurely.
+                newp[newp.length - 1] = new Property( ForgeConstants.EXTRA_DATA, pendingConnection.getExtraDataInHandshake().replaceAll( "\0", "\1"), "" );
+
+                // Set the properties in the profile. All done.
+                profile.setProperties( newp );
+            }
+        }
     }
 
     public void sendPacket(PacketWrapper packet)

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
@@ -14,6 +14,10 @@ public class ForgeConstants
     public static final String FML_HANDSHAKE_TAG = "FML|HS";
     public static final String FML_REGISTER = "REGISTER";
 
+    // Game profile key
+    public static final String FML_LOGIN_PROFILE = "forgeClient";
+    public static final String EXTRA_DATA = "extraData";
+
     /**
      * The FML 1.8 handshake token.
      */


### PR DESCRIPTION
This is identical to https://github.com/SpigotMC/BungeeCord/pull/1678, which has been in limbo for over a year, adding support for IP forwarding to Sponge servers. @ghacproductions expressed some interest on the Nucleus Discord to include this patch - it is a working, small patch that should not interfere with your update schedule. This will allow users of your Bungee fork to remove any plugins that patch in the IP forwarding in strange ways.

Details are below.

---

FML adds a \00FML\00 marker to the host field, so Forge can determine whether or not to start a Forge handshake, making way to allow vanilla clients to connect to Forge servers that don't need a client modification. However, Bungee also uses the field, and the two implementations collide when using Spigot.

The original fix was to not send the FML information at the same time as the IP forwarding, you could have one or the other, but not both. This was OK, as no FML servers supported IP forwarding as of time of the patch. This was implemented in commit 4809f1f80ace9ae87b91453c8887c70f5e098bd0.

However, there is now at least one Forge coremod that intends to support IP forwarding. To be able to support Forge with IP forwarding, a way to be able to support the FML token (and any other host data) is needed. This adds a property to the user Game Profile to forward on whether the user is a FML client, along with whether there is any extra data.

No breaking changes occur due to this patch.