### PR TITLE
Fix forwarding issue where the login profile is sometimes null.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee;
 
+import java.util.Arrays;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -91,15 +92,43 @@ public class ServerConnector extends PacketHandler
         if (BungeeCord.getInstance().config.isIpForward())
         {
             String newHost = copiedHandshake.getHost() + "\00" + user.getAddress().getHostString() + "\00" + user.getUUID();
-            
+
+            // Handle properties.
+            LoginResult.Property[] properties = new LoginResult.Property[0];
+
             LoginResult profile = user.getPendingConnection().getLoginProfile();
             if (profile != null && profile.getProperties() != null && profile.getProperties().length > 0)
+            {
                 newHost += "\00" + BungeeCord.getInstance().gson.toJson(profile.getProperties());
+            }
+
+            if ( user.getForgeClientHandler().isFmlTokenInHandshake() )
+            {
+                // Get the current properties and copy them into a slightly bigger array.
+                LoginResult.Property[] newp = Arrays.copyOf( properties, properties.length + 2 );
+
+                // Add a new profile property that specifies that this user is a Forge user.
+                newp[newp.length - 2] = new LoginResult.Property( ForgeConstants.FML_LOGIN_PROFILE, "true", null );
+
+                // If we do not perform the replacement, then the IP Forwarding code in Spigot et. al. will try to split on this prematurely.
+                newp[newp.length - 1] = new LoginResult.Property( ForgeConstants.EXTRA_DATA, user.getExtraDataInHandshake().replaceAll( "\0", "\1"), "" );
+
+                // All done.
+                properties = newp;
+            }
+
+            // If we touched any properties, then append them
+            if (properties.length > 0)
+            {
+                newHost += "\00" + BungeeCord.getInstance().gson.toJson(properties);
+            }
+
             copiedHandshake.setHost(newHost);
         }
-        else if (!user.getExtraDataInHandshake().isEmpty())
+        else if (!user.getExtraDataInHandshake().isEmpty()) {
             // Restore the extra data
             copiedHandshake.setHost(copiedHandshake.getHost() + user.getExtraDataInHandshake());
+        }
         
         channel.write(copiedHandshake);
         

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -11,7 +11,6 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.util.internal.PlatformDependent;
 import java.net.InetSocketAddress;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -38,8 +37,6 @@ import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.score.Scoreboard;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.connection.InitialHandler;
-import net.md_5.bungee.connection.LoginResult;
-import net.md_5.bungee.connection.LoginResult.Property;
 import net.md_5.bungee.entitymap.EntityMap;
 import net.md_5.bungee.forge.ForgeClientHandler;
 import net.md_5.bungee.forge.ForgeConstants;
@@ -58,7 +55,6 @@ import net.md_5.bungee.protocol.packet.ClientSettings;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
 import net.md_5.bungee.protocol.packet.PluginMessage;
-import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.SetCompression;
 import net.md_5.bungee.tab.ServerUnique;
 import net.md_5.bungee.tab.TabList;
@@ -185,29 +181,9 @@ public final class UserConnection implements ProxiedPlayer
 
         // No-config FML handshake marker.
         // Set whether the connection has a 1.8 FML marker in the handshake.
-        if (this.getPendingConnection().getExtraDataInHandshake().contains( ForgeConstants.FML_HANDSHAKE_TOKEN )) 
+        if (this.getPendingConnection().getExtraDataInHandshake().contains( ForgeConstants.FML_HANDSHAKE_TOKEN ))
         {
             forgeClientHandler.setFmlTokenInHandshake( true );
-
-            // If we IP forward, add the a FML marker to the game profile.
-            if ( BungeeCord.getInstance().config.isIpForward() ) 
-            {
-                // Get the user profile.
-                LoginResult profile = pendingConnection.getLoginProfile();
-
-                // Get the current properties and copy them into a slightly bigger array.
-                Property[] oldp = profile.getProperties();
-                Property[] newp = Arrays.copyOf( oldp, oldp.length + 2 );
-
-                // Add a new profile property that specifies that this user is a Forge user.
-                newp[newp.length - 2] = new Property( ForgeConstants.FML_LOGIN_PROFILE, "true", null );
-
-                // If we do not perform the replacement, then the IP Forwarding code in Spigot et. al. will try to split on this prematurely.
-                newp[newp.length - 1] = new Property( ForgeConstants.EXTRA_DATA, pendingConnection.getExtraDataInHandshake().replaceAll( "\0", "\1"), "" );
-
-                // Set the properties in the profile. All done.
-                profile.setProperties( newp );
-            }
         }
     }
 


### PR DESCRIPTION
My mistake - I should have been creating the profile properties later - my previous patch worked for me, but I hadn't realised that the Waterfall crew had updated my patch to be more resilliant. This is now identical to https://github.com/WaterfallMC/Waterfall/blob/master/BungeeCord-Patches/0012-Add-support-for-FML-with-IP-Forwarding-enabled.patch from Waterfall.

Fixes HexagonMC/BungeeCord#139