### PR TITLE
Fixed ArrayIndexOutOfBoundsException when connecting to a Thermos(?) server

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -286,7 +286,7 @@ public enum Protocol
 
         private final int protocolVersion;
         private final TObjectIntMap<Class<? extends DefinedPacket>> packetMap = new TObjectIntHashMap<>( MAX_PACKET_ID );
-        private final Constructor<? extends DefinedPacket>[] packetConstructors = new Constructor[ MAX_PACKET_ID ];
+        private final TIntObjectMap<Constructor<? extends DefinedPacket>> packetConstructors = new TIntObjectHashMap<>( MAX_PACKET_ID );
     }
 
     @RequiredArgsConstructor
@@ -362,7 +362,7 @@ public enum Protocol
                 throw new BadPacketException( "Packet with id " + id + " outside of range " );
             }
 
-            Constructor<? extends DefinedPacket> constructor = protocolData.packetConstructors[id];
+            Constructor<? extends DefinedPacket> constructor = protocolData.packetConstructors.get( id );
             try
             {
                 return ( constructor == null ) ? null : constructor.newInstance();
@@ -381,7 +381,7 @@ public enum Protocol
                 {
                     ProtocolData data = protocols.get( mapping.protocolVersion );
                     data.packetMap.put( packetClass, mapping.packetID );
-                    data.packetConstructors[mapping.packetID] = constructor;
+                    data.packetConstructors.put( mapping.packetID, constructor );
 
                     if (mapping.inherit)
                     {


### PR DESCRIPTION
Fixes the ArrayIndexOutOfBoundsException in v140+ when connecting to Thermos (and probably other?) servers (#152)

This change was introduced in HexagonMC/BungeeCord@29a32c6edb528d1ef3e4b16d528927f5b3f9d2ce and somehow breaks the connection. Although I don't know why that's causing it, simply reverting these changes fixes the issue.

EDIT: CoFHCore uses negative packet ids which breaks the array. SpigotMC/BungeeCord#1437